### PR TITLE
fix: 어드민페이지 새로고침현상 수정

### DIFF
--- a/src/pages/admin/components/docs/ApplyInfo.tsx
+++ b/src/pages/admin/components/docs/ApplyInfo.tsx
@@ -24,7 +24,8 @@ interface IApplyInfo {
 }
 
 const ApplyInfo = ({ track, submittedAt }: IApplyInfo) => {
-  const datePart = submittedAt.split(' ')[0];
+  const defaultDate = new Date().toLocaleDateString();
+  const datePart = submittedAt ? submittedAt.split(' ')[0] : defaultDate;
   const formattedDate = datePart.replace(/-/g, '. ');
 
   return (

--- a/src/pages/admin/components/docs/DocsTable.tsx
+++ b/src/pages/admin/components/docs/DocsTable.tsx
@@ -70,7 +70,7 @@ const DocsTable = ({
 
   const handleCloseModal = () => {
     setOpenDetail(null);
-    window.location.reload();
+    // window.location.reload();
   };
 
   useEffect(() => {


### PR DESCRIPTION
### ✨ 작업 내용

- 어드민페이지 새로고침현상 수정
- 지원날짜 null로 올 시 현재날짜로 들어가도록 처리

### ✨ 참고 사항

- isMarked 정보 넘기는 기능 아직 구현 안 됨
- 해당 기능까지 구현 후 이슈 닫을 예정

### ⏰ 현재 버그

---

### ✏ Git Close
