### PR TITLE
어드민페이지 모달창 닫을 때 마크 정보 넘기기 구현

### DIFF
--- a/src/apis/hooks/admin/docs/useGetApplyDocs.ts
+++ b/src/apis/hooks/admin/docs/useGetApplyDocs.ts
@@ -18,7 +18,8 @@ export const getApplyDocs = async (
   track: string,
   isMarked: boolean,
   page: number,
-  size: number
+  size: number,
+  classYearId: number
 ): Promise<applyDocsInterface> => {
   const response = await fetchInstance.get<applyDocsInterface>(
     getApplyDocsPath(),
@@ -28,6 +29,7 @@ export const getApplyDocs = async (
         isMarked,
         page,
         size,
+        classYearId,
       },
     }
   );
@@ -38,17 +40,19 @@ export const useGetApplyDocs = (
   track: string,
   isMarked: boolean,
   page: number,
-  size: number
+  size: number,
+  classYearId: number
 ) => {
   const accessToken = sessionStorage.getItem('accessToken');
 
   return useQuery<applyDocsInterface, Error>({
-    queryKey: [applyDocsQueryKey, track, isMarked, page, size],
-    queryFn: () => getApplyDocs(track, isMarked, page, size),
+    queryKey: [applyDocsQueryKey, track, isMarked, page, size, classYearId],
+    queryFn: () => getApplyDocs(track, isMarked, page, size, classYearId),
     enabled:
       !!accessToken &&
       track !== undefined &&
       isMarked !== undefined &&
-      page !== undefined,
+      page !== undefined &&
+      classYearId !== undefined,
   });
 };

--- a/src/apis/hooks/admin/docs/useGetDocsDetail.ts
+++ b/src/apis/hooks/admin/docs/useGetDocsDetail.ts
@@ -9,6 +9,7 @@ export type AnswerData = {
 
 export interface DocsDetailInterface {
   id: number;
+  version: number;
   name: string;
   studentNumber: string;
   major: string;

--- a/src/apis/hooks/admin/docs/useGetDocsDetail.ts
+++ b/src/apis/hooks/admin/docs/useGetDocsDetail.ts
@@ -38,6 +38,7 @@ export const getDocsDetail = async (
       },
     }
   );
+
   return response.data;
 };
 

--- a/src/apis/hooks/admin/docs/usePatchDocsMemo.ts
+++ b/src/apis/hooks/admin/docs/usePatchDocsMemo.ts
@@ -4,15 +4,21 @@ import { fetchInstance } from '@gdg/apis/instance/Api_JWT';
 
 const patchMemoPath = () => '/api/admin/application/note';
 
-const patchDocsMemo = async (id: number, memo: string): Promise<void> => {
-  // console.log(memo);
+const patchDocsMemo = async (
+  id: number,
+  memo: { note: string; version: number }
+): Promise<void> => {
   await fetchInstance.patch(patchMemoPath(), memo, { params: { id } });
 };
 
 export const usePatchDocsMemo = () => {
   const accessToken = sessionStorage.getItem('accessToken');
 
-  const mutation = useMutation<void, Error, { id: number; memo: string }>({
+  const mutation = useMutation<
+    void,
+    Error,
+    { id: number; memo: { note: string; version: number } }
+  >({
     mutationFn: ({ id, memo }) => {
       if (!accessToken) {
         return Promise.reject(new Error('액세스 토큰이 없습니다.'));

--- a/src/pages/admin/AdminDocConfirmPage.style.ts
+++ b/src/pages/admin/AdminDocConfirmPage.style.ts
@@ -16,6 +16,11 @@ export const PassBtn = styled.button<{ isSelected: boolean }>`
   transition: background-color 0.3s ease;
 `;
 
+export const ButtonContainer = styled.div`
+  width: auto;
+  height: 40px;
+`;
+
 export const ButtonBox = styled.div`
   display: flex;
   flex-direction: row;

--- a/src/pages/admin/AdminDocConfirmPage.tsx
+++ b/src/pages/admin/AdminDocConfirmPage.tsx
@@ -4,8 +4,13 @@ import { useGetStatistic } from '@gdg/apis/hooks/admin/docs/useGetStatistic';
 import { useGetTrack } from '@gdg/apis/hooks/admin/docs/useGetTrack';
 import { DisplayLayout } from '@gdg/styles/LayoutStyle';
 
-import { PassBtn, ButtonBox, InfoBox } from './AdminDocConfirmPage.style';
-
+import ClassYearIdDropDown from './components/docs/ClassYearIdDropDown';
+import {
+  PassBtn,
+  ButtonContainer,
+  ButtonBox,
+  InfoBox,
+} from './AdminDocConfirmPage.style';
 const TrackSelectBar = lazy(() => import('./components/docs/TrackSelectBar'));
 
 const DocsTable = lazy(
@@ -21,9 +26,15 @@ const AdminDocConfirmPage = () => {
   const [isMarked, setIsMarked] = useState<boolean>(false);
   const [searchName, setSearchName] = useState<string>('');
   const [trackIdx, setTrackIdx] = useState<number>(0);
+  const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+  const [classYearId, setClassYearId] = useState<number>(0);
 
   const handlePassCheck = () => {
     setIsMarked((prev) => !prev);
+  };
+
+  const handleClassYearIdCheck = () => {
+    setIsDropdownOpen((prev) => !prev);
   };
 
   const { data: applyData } = useGetStatistic();
@@ -45,6 +56,15 @@ const AdminDocConfirmPage = () => {
             <Stars color='white' />
             서류합격자 조회
           </PassBtn>
+          <ButtonContainer>
+            <PassBtn
+              isSelected={isDropdownOpen}
+              onClick={handleClassYearIdCheck}
+            >
+              기수별 조회
+            </PassBtn>
+            {isDropdownOpen && <ClassYearIdDropDown />}
+          </ButtonContainer>
         </ButtonBox>
         <AdminSearchBar onSearch={handleSearchNameChange} />
       </InfoBox>
@@ -52,6 +72,7 @@ const AdminDocConfirmPage = () => {
       {trackData && (
         <TrackSelectBar trackData={trackData} onSelect={handleTrackSelect} />
       )}
+
       <DocsTable
         searchName={searchName}
         trackIdx={trackIdx}

--- a/src/pages/admin/AdminDocConfirmPage.tsx
+++ b/src/pages/admin/AdminDocConfirmPage.tsx
@@ -27,7 +27,7 @@ const AdminDocConfirmPage = () => {
   const [searchName, setSearchName] = useState<string>('');
   const [trackIdx, setTrackIdx] = useState<number>(0);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
-  const [classYearId, setClassYearId] = useState<number>(0);
+  const [classYearId, setClassYearId] = useState<number>(1);
 
   const handlePassCheck = () => {
     setIsMarked((prev) => !prev);
@@ -35,6 +35,10 @@ const AdminDocConfirmPage = () => {
 
   const handleClassYearIdCheck = () => {
     setIsDropdownOpen((prev) => !prev);
+  };
+
+  const handleYearIdClick = (id: number) => {
+    setClassYearId(id);
   };
 
   const { data: applyData } = useGetStatistic();
@@ -63,7 +67,9 @@ const AdminDocConfirmPage = () => {
             >
               기수별 조회
             </PassBtn>
-            {isDropdownOpen && <ClassYearIdDropDown />}
+            {isDropdownOpen && (
+              <ClassYearIdDropDown onYearIdClick={handleYearIdClick} />
+            )}
           </ButtonContainer>
         </ButtonBox>
         <AdminSearchBar onSearch={handleSearchNameChange} />
@@ -77,6 +83,7 @@ const AdminDocConfirmPage = () => {
         searchName={searchName}
         trackIdx={trackIdx}
         isMarked={isMarked}
+        classYearId={classYearId}
       />
     </DisplayLayout>
   );

--- a/src/pages/admin/AdminDocConfirmPage.tsx
+++ b/src/pages/admin/AdminDocConfirmPage.tsx
@@ -39,6 +39,7 @@ const AdminDocConfirmPage = () => {
 
   const handleYearIdClick = (id: number) => {
     setClassYearId(id);
+    setIsDropdownOpen(false);
   };
 
   const { data: applyData } = useGetStatistic();

--- a/src/pages/admin/AdminDocConfirmPage.tsx
+++ b/src/pages/admin/AdminDocConfirmPage.tsx
@@ -27,7 +27,7 @@ const AdminDocConfirmPage = () => {
   const [searchName, setSearchName] = useState<string>('');
   const [trackIdx, setTrackIdx] = useState<number>(0);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
-  const [classYearId, setClassYearId] = useState<number>(1);
+  const [classYearId, setClassYearId] = useState<number>(4);
 
   const handlePassCheck = () => {
     setIsMarked((prev) => !prev);
@@ -66,7 +66,7 @@ const AdminDocConfirmPage = () => {
               isSelected={isDropdownOpen}
               onClick={handleClassYearIdCheck}
             >
-              기수별 조회
+              {`${classYearId}기 ${'\u00A0'} ▾`}
             </PassBtn>
             {isDropdownOpen && (
               <ClassYearIdDropDown onYearIdClick={handleYearIdClick} />

--- a/src/pages/admin/components/docs/ApplyDetailModal.style.ts
+++ b/src/pages/admin/components/docs/ApplyDetailModal.style.ts
@@ -120,10 +120,10 @@ export const SelfIntroduce = styled.div`
   overflow-y: scroll;
 
   color: black;
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   font-weight: 200;
 
-  margin-top: 5px;
+  margin-top: 10px;
 `;
 
 export const ButtonContainer = styled.div`

--- a/src/pages/admin/components/docs/ApplyDetailModal.style.ts
+++ b/src/pages/admin/components/docs/ApplyDetailModal.style.ts
@@ -14,7 +14,7 @@ export const ModalBackdrop = styled.div`
 export const ModalWrapper = styled.div`
   width: 90%;
   height: 85vh;
-  min-width: 900px;
+  max-width: 1100px;
   min-height: 500px;
 
   ${displayCenter}

--- a/src/pages/admin/components/docs/ApplyDetailModal.tsx
+++ b/src/pages/admin/components/docs/ApplyDetailModal.tsx
@@ -142,6 +142,7 @@ const ApplyDetailModal = ({
   };
 
   const trackData = detail ? getQuestionsByTrack(detail.track) : null;
+  const emptyAnswer = '해당 질문에 대한 답변이 작성되지 않았습니다.';
 
   return (
     <ModalBackdrop>
@@ -177,7 +178,7 @@ const ApplyDetailModal = ({
                 <SelfIntroduce>
                   {detail.answers.length > 0
                     ? `${detail.answers[0].answer}`
-                    : `${trackData.Question1.main}란이 비어있습니다.`}
+                    : emptyAnswer}
                 </SelfIntroduce>
                 <DividingLine />
 
@@ -187,7 +188,7 @@ const ApplyDetailModal = ({
                 <SelfIntroduce>
                   {detail.answers.length > 1
                     ? `${detail.answers[1].answer}`
-                    : `${trackData.Question2.main}란이 비어있습니다.`}
+                    : emptyAnswer}
                 </SelfIntroduce>
                 <DividingLine />
 
@@ -197,7 +198,7 @@ const ApplyDetailModal = ({
                 <SelfIntroduce>
                   {detail.answers.length > 2
                     ? `${detail.answers[2].answer}`
-                    : `${trackData.Question3.main}란이 비어있습니다.`}
+                    : emptyAnswer}
                 </SelfIntroduce>
                 <DividingLine />
 
@@ -207,7 +208,7 @@ const ApplyDetailModal = ({
                 <SelfIntroduce>
                   {detail.answers.length > 3
                     ? `${detail.answers[3].answer}`
-                    : `${trackData.Question4.main}란이 비어있습니다.`}
+                    : emptyAnswer}
                 </SelfIntroduce>
                 <DividingLine />
               </IntroContainer>

--- a/src/pages/admin/components/docs/ApplyDetailModal.tsx
+++ b/src/pages/admin/components/docs/ApplyDetailModal.tsx
@@ -143,6 +143,7 @@ const ApplyDetailModal = ({
 
   const trackData = detail ? getQuestionsByTrack(detail.track) : null;
   const emptyAnswer = '해당 질문에 대한 답변이 작성되지 않았습니다.';
+  console.log(detail?.answers);
 
   return (
     <ModalBackdrop>

--- a/src/pages/admin/components/docs/ApplyDetailModal.tsx
+++ b/src/pages/admin/components/docs/ApplyDetailModal.tsx
@@ -55,6 +55,7 @@ interface Answer {
 
 interface DetailInfo {
   id: number;
+  version: number;
   name: string;
   studentNumber: string;
   major: string;
@@ -143,7 +144,8 @@ const ApplyDetailModal = ({
 
   const trackData = detail ? getQuestionsByTrack(detail.track) : null;
   const emptyAnswer = '해당 질문에 대한 답변이 작성되지 않았습니다.';
-  console.log(detail?.answers);
+
+  console.log(detail);
 
   return (
     <ModalBackdrop>
@@ -236,7 +238,11 @@ const ApplyDetailModal = ({
                 <DividingLine />
                 <TechStack techStack={detail.techStack} link={detail.link} />
                 <DividingLine />
-                <Memo id={detail.id} note={detail.note} />
+                <Memo
+                  id={detail.id}
+                  version={detail.version}
+                  note={detail.note}
+                />
                 <DividingLine />
                 <ButtonContainer>
                   <CommonBtn

--- a/src/pages/admin/components/docs/ApplyDetailModalSkeleton.tsx
+++ b/src/pages/admin/components/docs/ApplyDetailModalSkeleton.tsx
@@ -76,7 +76,7 @@ const ApplyDetailModalSkeleton = () => {
           <DividingLine />
           <TechStack techStack='  ,  ,  ' link='' />
           <DividingLine />
-          <Memo id={null} note='' />
+          <Memo id={null} version={0} note='' />
           <DividingLine />
           <ButtonContainer>
             <CommonBtn

--- a/src/pages/admin/components/docs/ClassYearIdDropDown.tsx
+++ b/src/pages/admin/components/docs/ClassYearIdDropDown.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+import { displayCenter } from '@gdg/styles/LayoutStyle';
+
+import { DividingLine } from './ApplyDetailModal.style';
+
+const DropdownContainer = styled.div`
+  position: relative;
+  top: 0;
+  left: 0;
+  margin-top: 2px;
+  z-index: 10;
+
+  background-color: var(--color-white);
+  border-radius: 12px;
+  padding: 15px;
+
+  ${displayCenter}
+  align-items: center;
+  flex-direction: column;
+`;
+
+const YearIdButton = styled.div`
+  ${displayCenter}
+
+  width: 100%;
+
+  background-color: transparent;
+  color: var(--color-black);
+  border: none;
+  outline: none;
+
+  &:hover {
+    cursor: pointer;
+    font-weight: bold;
+  }
+`;
+
+const ClassYearIdDropDown = () => {
+  return (
+    <DropdownContainer>
+      <YearIdButton>1기</YearIdButton>
+      <DividingLine />
+      <YearIdButton>2기</YearIdButton>
+      <DividingLine />
+      <YearIdButton>3기</YearIdButton>
+      <DividingLine />
+      <YearIdButton>4기</YearIdButton>
+    </DropdownContainer>
+  );
+};
+
+export default ClassYearIdDropDown;

--- a/src/pages/admin/components/docs/ClassYearIdDropDown.tsx
+++ b/src/pages/admin/components/docs/ClassYearIdDropDown.tsx
@@ -36,16 +36,23 @@ const YearIdButton = styled.div`
   }
 `;
 
-const ClassYearIdDropDown = () => {
+const ClassYearIdDropDown = ({
+  onYearIdClick,
+}: {
+  onYearIdClick: (id: number) => void;
+}) => {
+  const yearIdList = [1, 2, 3, 4];
+
   return (
     <DropdownContainer>
-      <YearIdButton>1기</YearIdButton>
-      <DividingLine />
-      <YearIdButton>2기</YearIdButton>
-      <DividingLine />
-      <YearIdButton>3기</YearIdButton>
-      <DividingLine />
-      <YearIdButton>4기</YearIdButton>
+      {yearIdList.map((id) => (
+        <div key={id}>
+          <YearIdButton
+            onClick={() => onYearIdClick(id)}
+          >{`${id}기`}</YearIdButton>
+          {id < yearIdList.length && <DividingLine />}
+        </div>
+      ))}
     </DropdownContainer>
   );
 };

--- a/src/pages/admin/components/docs/DocsTable.tsx
+++ b/src/pages/admin/components/docs/DocsTable.tsx
@@ -56,7 +56,7 @@ const DocsTable = ({
   const [docsList, setDocsList] = useState<applyDocsInterface | null>(null);
   const [openDetail, setOpenDetail] = useState<number | null>(null);
 
-  const { data: docsData } = useGetApplyDocs(
+  const { data: docsData, refetch: refetchDocs } = useGetApplyDocs(
     getTrack(trackIdx),
     isMarked,
     currentPage,
@@ -70,7 +70,7 @@ const DocsTable = ({
 
   const handleCloseModal = () => {
     setOpenDetail(null);
-    // window.location.reload();
+    refetchDocs();
   };
 
   useEffect(() => {

--- a/src/pages/admin/components/docs/DocsTable.tsx
+++ b/src/pages/admin/components/docs/DocsTable.tsx
@@ -46,10 +46,12 @@ const DocsTable = ({
   searchName,
   trackIdx,
   isMarked,
+  classYearId,
 }: {
   searchName?: string | undefined;
   trackIdx: number;
   isMarked: boolean;
+  classYearId: number;
 }) => {
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [currentGroup, setCurrentGroup] = useState<number>(0);
@@ -60,7 +62,8 @@ const DocsTable = ({
     getTrack(trackIdx),
     isMarked,
     currentPage,
-    7
+    7,
+    classYearId
   );
   const { data: searchData } = useGetSearch(searchName, currentPage, 7);
 

--- a/src/pages/admin/components/docs/Memo.tsx
+++ b/src/pages/admin/components/docs/Memo.tsx
@@ -38,12 +38,30 @@ const MemoBox = styled.textarea`
   outline: none;
 `;
 
-const Memo = ({ id, note }: { id: number | null; note: string | null }) => {
-  const [memo, setMemo] = useState<string | null>(note || null);
+interface IMemo {
+  note: string;
+  version: number;
+}
+
+const Memo = ({
+  id,
+  version,
+  note,
+}: {
+  id: number | null;
+  version: number;
+  note: string | null;
+}) => {
+  const [memo, setMemo] = useState<IMemo | null>(
+    note !== null ? { note: note, version: version } : null
+  );
   const { mutate } = usePatchDocsMemo();
 
   const handleMemoBoxChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setMemo(e.target.value);
+    setMemo({
+      note: e.target.value,
+      version: version,
+    });
   };
 
   const handleSaveClick = () => {
@@ -87,7 +105,7 @@ const Memo = ({ id, note }: { id: number | null; note: string | null }) => {
       </TitleWrapper>
       <MemoBox
         placeholder='간단한 메모를 해보세요!'
-        value={memo ? memo.replace(/['"]/g, '').replace(/\\n/g, '\n') : ''}
+        value={memo ? memo.note.replace(/['"]/g, '').replace(/\\n/g, '\n') : ''}
         onChange={handleMemoBoxChange}
       />
     </MemoWrapper>

--- a/src/pages/admin/components/docs/Memo.tsx
+++ b/src/pages/admin/components/docs/Memo.tsx
@@ -87,7 +87,7 @@ const Memo = ({ id, note }: { id: number | null; note: string | null }) => {
       </TitleWrapper>
       <MemoBox
         placeholder='간단한 메모를 해보세요!'
-        value={memo ? memo.replace(/['"]/g, '') : ''}
+        value={memo ? memo.replace(/['"]/g, '').replace(/\\n/g, '\n') : ''}
         onChange={handleMemoBoxChange}
       />
     </MemoWrapper>


### PR DESCRIPTION
### ✨ 작업 내용

- 어드민페이지 모달창 닫을 때 마크 정보 넘기기 구현
- 서류확인 모달창 css 수정
- 빈 답변에 대한 안내문구 내용 수정

### ✨ 참고 사항

- 답변 글씨 크기를 12px -> 14px이 더 나을 것 같다는 생각이 듭니다. 다같이 논의해 보면 좋겠습니다
<img width="1708" alt="image" src="https://github.com/user-attachments/assets/1923607d-24e0-4c46-aa89-5a5a9812c069" />


### ⏰ 현재 버그

- 없음

### ✏ Git Close
#177 